### PR TITLE
ignore invalid tags if they exist

### DIFF
--- a/main.go
+++ b/main.go
@@ -235,13 +235,13 @@ func (c *CLI) currentVersion() (*semver.Version, error) {
 		return v, nil
 	}
 
-	vs := make([]*semver.Version, len(tags))
-	for i, tag := range tags {
+	vs := make([]*semver.Version, 0)
+	for _, tag := range tags {
 		v, err := semver.NewVersion(tag)
 		if err != nil {
 			continue
 		}
-		vs[i] = v
+		vs = append(vs, v)
 	}
 
 	sort.Sort(semver.Collection(vs))


### PR DESCRIPTION
This PR fixes: https://github.com/b4b4r07/git-bump/issues/1

If a tag exists in the repo that is not of semver format, it crashes. This fix simply ignores tags that are not semver tags. It was having trouble sorting the list (line 247) that included nil values.