### PR TITLE
support authentication via SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Download the binary from [GitHub Releases][release] and drop it in your `$PATH`.
 - [Darwin / Mac][release]
 - [Linux][release]
 
+## Configuration
+
+This project makes use of the following environment variables.
+
+- `GITHUB_TOKEN` - authenticate against Github repositories using an [access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token)
+- `SSH_KEY` - authenticate to remote origin using this SSH key
+
 ## License
 
 [MIT][license]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 git-bump
 ========
 
+this is a fork of [github.com/b4b4r07/git-bump](https://github.com/b4b4r07/git-bump). Forked because it's abandoned and I
+want to install git-bump with my [PR](https://github.com/b4b4r07/git-bump/pull/5) :)
+
+-------
+
 Bump version (git tag) to next one with [semver](https://semver.org/).
 
 ![](demo.png)
@@ -44,5 +49,5 @@ This project makes use of the following environment variables.
 
 [MIT][license]
 
-[release]: https://github.com/b4b4r07/git-bump/releases/latest
+[release]: https://github.com/justmiles/git-bump/releases/latest
 [license]: https://b4b4r07.mit-license.org

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/b4b4r07/git-bump
+module github.com/justmiles/git-bump
 
 go 1.12
 


### PR DESCRIPTION
Hi! Thanks for writing this - I've found it to be very useful. 

Not all of my repositories are in Github. I was able to use this by adding the ability to authenticate via SSH. Similar to the `GITHUB_TOKEN`, this is done by setting the `SSH_KEY` environment variable. 