### PR TITLE
Fixed build failure on macOS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mattn/go-colorable v0.1.4 // indirect
+	golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 )

--- a/go.sum
+++ b/go.sum
@@ -81,13 +81,13 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d h1:/m5NbqQelATgoSPVC2Z23sR4kVNokFwDDyWh/3rGY+I=
+golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a h1:mEQZbbaBjWyLNy0tmZmgEuQAR8XOQ3hL8GYi3J/NG64=
 golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=


### PR DESCRIPTION
Environment
```
❯ sw_vers
ProductName:	macOS
ProductVersion:	12.4
BuildVersion:	21F79

❯ go version
go version go1.18.3 darwin/amd64
```

Build results.
```
❯ go install github.com/b4b4r07/git-bump@master
go: downloading github.com/b4b4r07/git-bump v0.1.2-0.20220201053720-04763c0c900f
# golang.org/x/sys/unix
go/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
go/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
go/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
go/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
go/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
go/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
go/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
go/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:136:3: //go:linkname must refer to declared function or variable
go/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:151:3: //go:linkname must refer to declared function or variable
go/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:166:3: //go:linkname must refer to declared function or variable
go/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:166:3: too many errors
```

I don't know what caused it, but after updating `golang.org/x/sys` it is now buildable.

Signed-off-by: kouki <kouworld0123@gmail.com>